### PR TITLE
Vagrant setup

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,31 @@
+VAGRANT_COMMAND = ARGV[0]
+
+Vagrant.configure("2") do |config|
+  # Popular base box, should work!
+  config.vm.box = "ubuntu/trusty64"
+
+  # Forward expected guest Jenkins to host 8080
+  config.vm.network "forwarded_port", guest: 8080, host: 8080
+
+  # Use root on subsequent vagrant ssh calls because easy and secure, right? Throwaway dev box :-)
+  if VAGRANT_COMMAND == "ssh"
+    config.ssh.username = 'root'
+    config.ssh.insert_key = 'false'
+  end
+
+  # Install Docker and Docker Compose, validate, and support login directly as root using the Vagrant insecure key
+  config.vm.provision "shell", inline: <<-SHELL
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+    apt-get update
+    apt-get install -y docker-ce
+
+    curl -L https://github.com/docker/compose/releases/download/1.22.0/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose
+    chmod +x /usr/local/bin/docker-compose
+
+    docker --version
+    docker-compose --version
+
+    cp /home/vagrant/.ssh/authorized_keys /root/.ssh
+  SHELL
+end


### PR DESCRIPTION
#### What does this PR do?

Adds a `Vagrantfile` that lets a user work without using a local Docker as both it and Docker Compose are installed inside the Vagrant environment. `/vagrant` is mapped to the workspace so you can work inside the box in that dir the same as you would at the root of the workspace, even mixing and matching (for instance use a text editor like Atom in the real workspace and a terminal inside Vagrant for running the Docker commands)

#### Why did you take this approach?

Am personally testing using a local Docker install on a Mac, but others have expressed interest in working on the project on other systems where either a local Docker install isn't desirable or even possible (Windows). I'd also like to work on it myself on other systems. Broader base of possible contributors ftw! :-)

#### Contribution checklist

- [x] THERE ARE NO UNENCRYPTED SECRETS HERE
- [x] The branch is named something meaningful
- [x] The branch is rebased off of current master
- [x] There is a single commit (or very few smaller ones) with a [Good commit message](https://github.com/torvalds/subsurface-for-dirk/blob/master/README#L92) that includes the issue if there was one
- [x] You have tested this locally yourself