### PR TITLE
Hobo GitOps!

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,7 +23,9 @@ Vagrant.configure("2") do |config|
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
     add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
     apt-get update
-    apt-get install -y docker-ce dos2unix
+
+    # Temporarily tied to a specific version of Docker due to https://github.com/docker/for-linux/issues/591
+    apt-get install -y docker-ce=18.06.1~ce~3-0~ubuntu dos2unix
 
     curl -L https://github.com/docker/compose/releases/download/1.22.0/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose
     chmod +x /usr/local/bin/docker-compose

--- a/images/jenkins-base/Dockerfile
+++ b/images/jenkins-base/Dockerfile
@@ -24,8 +24,20 @@ ENV JENKINS_SHA d8ed5a7033be57aa9a84a5342b355ef9f2ba6cdb490db042a6d03efb23ca1e83
 ENV JENKINS_UC https://updates.jenkins.io
 ENV JENKINS_URL https://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-war/${JENKINS_VERSION}/jenkins-war-${JENKINS_VERSION}.war
 
-# Optional extra hook for Job DSL examples, used in one of the init scripts if present. No env var == no job DSL set up
-ENV DSL_REPO https://github.com/sheehan/job-dsl-gradle-example.git
+# Optional extra hook for Job DSL examples, used in one of the init scripts if present. No DSL repo env var == no job DSL set up
+ENV GITOPS_DSL_REPO https://github.com/Cervator/GitOpsUtilityJobs.git
+
+# The manifest repo is meant to contain additional configuration
+ENV GITOPS_MANIFEST_REPO https://github.com/Cervator/GitOpsManifest.git
+
+# This context allows a set of tiered Jenkins Masters to pull config out from a specific tier
+ENV GITOPS_JENKINS_CONTEXT dev
+
+# Default examples work without credentials but will read this one if set (creating it in Jenkins is a different topic)
+# ENV GIT_CREDENTIAL SomeCredential
+
+# Optional extra - set a different branch to use by default (which is master)
+# ENV GITOPS_PLATFORM_LEVEL develop
 
 # Jenkins is run with user `jenkins`, uid = 1000
 # If you bind mount a volume from the host or a data container,

--- a/images/jenkins-plugins/files/dslScripts/GentleRestartJenkins.groovy
+++ b/images/jenkins-plugins/files/dslScripts/GentleRestartJenkins.groovy
@@ -1,21 +1,21 @@
-job('JenkinsGentleRestart') {
+job('BundledJenkinsGentleRestart') {
     description('Gently swaddles Jenkins into goodnight mode, sings it a lullaby while waiting for any jobs to finish, then restarts.')
     label("master")
     steps {
         systemGroovyCommand ('''
             /*
                 Copyright (c) 2015-2018 Sam Gleske - https://github.com/samrocketman/jenkins-script-console-scripts
-    
+
                 Permission is hereby granted, free of charge, to any person obtaining a copy of
                 this software and associated documentation files (the "Software"), to deal in
                 the Software without restriction, including without limitation the rights to
                 use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
                 the Software, and to permit persons to whom the Software is furnished to do so,
                 subject to the following conditions:
-    
+
                 The above copyright notice and this permission notice shall be included in all
                 copies or substantial portions of the Software.
-    
+
                 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
                 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
                 FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
@@ -27,32 +27,32 @@ job('JenkinsGentleRestart') {
                This script starts a background thread which will wait for Jenkins to finish
                executing jobs before restarting.  The thread will abort if shutdown mode is
                disabled before jobs finish.
-    
+
                Tested on Jenkins ver. 2.7.1
             */
-    
+
             import hudson.model.RestartListener
             import java.util.logging.Level
             import java.util.logging.Logger
             import jenkins.model.*
-    
+
             //user configurable variable
             if(!binding.hasVariable('timeout_seconds')) {
                 timeout_seconds = 10
             }
-    
+
             if(timeout_seconds in String) {
                 timeout_seconds = Integer.decode(timeout_seconds)
             }
-    
+
             //type check user defined parameters/bindings
             if(!(timeout_seconds in Integer)) {
                 throw new Exception('PARAMETER ERROR: timeout_seconds must be an integer.')
             }
-    
+
             Logger logger = Logger.getLogger('jenkins.instance.restart')
             Jenkins.instance.doQuietDown();
-    
+
             //start a background thread
             def thread = Thread.start {
                 logger.log(Level.INFO, "Jenkins safe restart initiated.")
@@ -70,7 +70,7 @@ job('JenkinsGentleRestart') {
                     }
                 }
             }
-    
+
             println 'A safe restart has been scheduled.  See the Jenkins logs for restart status updates.  Logger is jenkins.instance.restart.'
         ''')
     }

--- a/images/jenkins-plugins/files/init.groovy.d/03_PrepDSL.groovy
+++ b/images/jenkins-plugins/files/init.groovy.d/03_PrepDSL.groovy
@@ -5,26 +5,25 @@ import javaposse.jobdsl.plugin.JenkinsJobManagement
 import jenkins.model.Jenkins
 
 // Make the Job DSL integration optional. Fairly easy to come up with different ways to trigger it. Env vars are simple.
-if (! System.getenv("DSL_REPO")) {
+if (! System.getenv("GITOPS_DSL_REPO")) {
     println "No DSL repo defined, skipping DSL prep"
     return
 }
 
-// Create the seed job itself, so it can run and create the "real" DSL-managed jobs
+// Create the utility seed job, so it can run and create various DSL-managed utility jobs from a target DSL repo
 def jobDslScript = new File("/var/jenkins_home/init.groovy.d/SeedJobDSL.groovy.DSL")
 def workspace = new File("/tmp/dsl")
 def jobManagement = new JenkinsJobManagement(System.out, [:], workspace)
 new DslScriptLoader(jobManagement).runScript(jobDslScript.text)
 
 // Schedule the job to run so the jobs are created when Jenkins starts - or skip this for more control
-Jenkins.instance.getItemByFullName('seed-job', FreeStyleProject.class).scheduleBuild(new UserIdCause())
+Jenkins.instance.getItemByFullName('SeedJobUtilityDSL', FreeStyleProject.class).scheduleBuild(new UserIdCause())
 
-
-// Secondary job seeder using a local dir
+// Secondary seed job used to demonstrate loading a file directly instead of a repository
 def jobDslScript2 = new File("/var/jenkins_home/init.groovy.d/SeedJobDSL2.groovy.DSL")
 def workspace2 = new File("/tmp/dsl")
 def jobManagement2 = new JenkinsJobManagement(System.out, [:], workspace2)
 new DslScriptLoader(jobManagement2).runScript(jobDslScript2.text)
 
 // Schedule the job to run so the jobs are created when Jenkins starts.
-Jenkins.instance.getItemByFullName('seed-job2', FreeStyleProject.class).scheduleBuild(new UserIdCause())
+Jenkins.instance.getItemByFullName('SeedJobInternal', FreeStyleProject.class).scheduleBuild(new UserIdCause())

--- a/images/jenkins-plugins/files/init.groovy.d/SeedJobDSL.groovy.DSL
+++ b/images/jenkins-plugins/files/init.groovy.d/SeedJobDSL.groovy.DSL
@@ -1,8 +1,8 @@
-job('seed-job') {
-    description('Seed Job to create other DSL-based jobs')
+job('SeedJobUtilityDSL') {
+    description('Seed Job to create DSL repo-provided utility jobs')
     label("master")
     scm {
-        git("${System.getenv("DSL_REPO")}")
+        git("${System.getenv("GITOPS_DSL_REPO")}")
     }
     triggers {
         // Every 15 minutes poll to see if there are new changes

--- a/images/jenkins-plugins/files/init.groovy.d/SeedJobDSL2.groovy.DSL
+++ b/images/jenkins-plugins/files/init.groovy.d/SeedJobDSL2.groovy.DSL
@@ -1,5 +1,5 @@
-job('seed-job2') {
-    description('Seed Job to create other DSL-based jobs')
+job('SeedJobInternal') {
+    description('Seed Job to showcase using DSL from scripts stored locally')
     label("master")
     customWorkspace('/var/jenkins_home/dslScripts')
     concurrentBuild(false)

--- a/images/jenkins-plugins/files/plugins.txt
+++ b/images/jenkins-plugins/files/plugins.txt
@@ -7,3 +7,6 @@ job-dsl
 cloudbees-folder
 gradle
 email-ext
+startup-trigger-plugin
+workflow-cps-global-lib
+matrix-auth


### PR DESCRIPTION
#### What does this PR do?

Introduces a Hobo-rific approach to [GitOps: Operations by pull request](https://www.weave.works/blog/gitops-operations-by-pull-request), or really just one step on the way there, namely putting more things under Git control that's specific to some sort of workflow. Goes with:

* https://github.com/Cervator/GitOpsManifest - a tiny amount of configuration meant to help define a Jenkins' uniqueness via Git. An eventual goal is to use Jenkins CasC-compatible YAML instead.
* https://github.com/Cervator/GitOpsUtilityJobs - a few DSL-based jobs that do things to Jenkins itself based on config retrieved from the manifest. Allows run-time application of changes rather than rely on restarting Jenkins to pick up changes from init scripts or CasC files, yet by using the same config.

This is still one step away from proper GitOps in applying changes to a live environment for some software project - however - it also kinda achieves that since this sort of Hobo GitOps is meant to help maintain the GitOps _itself_ as such an expression of organized control.

There is a chain of seed jobs included that ultimately point at a pretend-team target Job DSL repo that normally would be the GitOps magic meant to help promote an actual application being managed this way. For the moment the ultimate seed job is just pointed at https://github.com/Cervator/job-dsl-gradle-example which is my fork of a nice but unrelated set of more advanced Job DSL techniques, shrunken down a bit.

As such the main thing missing is an actual pretend-app being maintained by this project. Secondly I'd like to include more hooks for using this to entangle _multiple_ such projects, in separate Jenkins Masters if necessary.

#### Why did you take this approach?

GitOps is cool. Version control all the things!

Probably this could be hard to make sense of in its current shape without further guidance. It is a watered down demo version of what I've been working on professionally for some time now, and may demo at a Jenkins Days event coming to a town near you ...

Flexibility has been a core concern here, with the idea being that actual serviced teams could arrive with a variety of needs and technology and preferences and so on. They might even leave again and come back depending on management directives and so on. Hobos, really, in the world of shiny but occasionally rigid tools or other requirements that may have far more stringent constraints than some teams may be ready to adopt, such as a full on Kubernetes implementation. 

The fancy tools may still be in use by _some_ teams, where this process then just ceases after plugging in some details via GitOps that "Thing X is supposed to look like Y", leaving it up to a next layering of tools to make that happen in a given environment.

#### Contribution checklist

- [x] THERE ARE NO UNENCRYPTED SECRETS HERE
- [x] The branch is named something meaningful
- [kinda] The branch is rebased off of current master
- [x] There is a single commit (or very few smaller ones) with a [Good commit message](https://github.com/torvalds/subsurface-for-dirk/blob/master/README#L92) that includes the issue if there was one
- [x] You have tested this locally yourself

#### A picture of a cute animal (optional)
<img src="https://avatars2.githubusercontent.com/u/7417788?s=400&u=c00acccbda47c4881878e48373bb2804e39d929f&v=4"/>
