### PR TITLE
Updating Vagrant's image, and the gitignore, due to new logs showing up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ Thumbs.db
 # Ignore other
 .vagrant
 .gradle
+
+# Ignore top level logs
+*.log

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,7 @@ VAGRANT_COMMAND = ARGV[0]
 
 Vagrant.configure("2") do |config|
   # Popular base box, should work!
-  config.vm.box = "ubuntu/trusty64"
+  config.vm.box = "ubuntu/bionic64"
 
   config.vm.provider "virtualbox" do |v|
     v.memory = 2048


### PR DESCRIPTION
#### What does this PR do?
This PR brings our vagrant box up to the latest LTS of ubuntu. 
It also ignores a new log at the top level that ubuntu bionic seems to output

#### Why did you take this approach?
This is the way to upgrade this vagrant image

#### Contribution checklist

- [X] THERE ARE NO UNENCRYPTED SECRETS HERE
- [X] The branch is named something meaningful
- [X] The branch is rebased off of current master
- [X] There is a single commit (or very few smaller ones) with a [Good commit message](https://github.com/torvalds/subsurface-for-dirk/blob/master/README#L92) that includes the issue if there was one
- [X] You have tested this locally yourself


#### A picture of a cute animal (optional)
<img src="https://i.imgur.com/N875hFR.jpg" width="350"/>
